### PR TITLE
updated logic to check last day of the month instead of 30th

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2,13 +2,19 @@ var message = null;
 var d = new Date();
 var today = d.getDate(); // return the day of the month as a number 0-30
 var month = d.getMonth(); // return month as a number 0-11
+var year = d.getFullYear();
 var months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
 var payDay = document.getElementById("PayDay");
 
-// Is today's date the 15 or the 30th? If yes...
+// used to calculate the last day of month -- especially helpful for February
+var lastday = function(y,m){
+return  new Date(y, m +1, 0).getDate();
+}
 
-if ( today == 15 || today == 30) {
-	message = "Yay! It's Payday!";	
+// Is today's date the 15 or the last day of the month? If yes...
+
+if ( today == 15 || today == lastday(year,month)) {
+	message = "Yay! It's Payday!";
 }
 
 // If not...


### PR DESCRIPTION
I updated the logic instead of checking to see if it's the 15th or 30th of month it checks if it is the 15th or the _last_ day of month which is helpful for February and months with 31 days where the payday would not be on the 30th. 